### PR TITLE
chore: modernize Terraform and provider versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ output "client_secret" {
 # Versions
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.22"
+      version = "~> 3.116"
     }
     azurenoopsutils = {
       source  = "POps-Rox/azurenoopsutils"

--- a/docs/index.md
+++ b/docs/index.md
@@ -120,11 +120,11 @@ output "client_secret" {
 # Versions
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.22"
+      version = "~> 3.116"
     }
     azurenoopsutils = {
       source  = "POps-Rox/azurenoopsutils"

--- a/remote-state-generator/versions.tf
+++ b/remote-state-generator/versions.tf
@@ -2,15 +2,15 @@
 # Licensed under the MIT License.
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.22"
+      version = "~> 3.116"
     }
     azurenoopsutils = {
       source  = "azurenoops/azurenoopsutils"
-      version = "~> 1.0"
+      version = "~> 1.0.4"
     }
   }
 }


### PR DESCRIPTION
## Summary
Modernize version constraints to current standards.
### Changes
- Terraform `>= 1.9`
- azurerm `~> 3.116`
- Updated examples and documentation
Closes #1