### PR TITLE
feat: remove azurenoops provider dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <!-- BADGES:END -->
 
 # Azure Remote-State Accelerator Terraform Overlay
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-template/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-remotestate/azurerm/)
 
 Terraform Module with GitHub Actions templates intended to lower development, testing, and deployment.
 
@@ -126,8 +126,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "POps-Rox/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0"
     }
   }

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0"
     }
   }

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 <!-- BADGES:END -->
 
 # Azure Remote-State Accelerator Terraform Overlay
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-template/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-remotestate/azurerm/)
 
 Terraform Module with GitHub Actions templates intended to lower development, testing, and deployment.
 
@@ -126,8 +126,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "POps-Rox/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0"
     }
   }

--- a/docs/index.md
+++ b/docs/index.md
@@ -127,7 +127,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0"
     }
   }

--- a/modules.remotestate.tf
+++ b/modules.remotestate.tf
@@ -64,7 +64,7 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.22"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
       version = "~> 1.0"
     }

--- a/modules.remotestate.tf
+++ b/modules.remotestate.tf
@@ -65,7 +65,7 @@ terraform {
       version = "~> 3.22"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0"
     }
   }

--- a/modules.remotestate.tf
+++ b/modules.remotestate.tf
@@ -64,8 +64,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.22"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0"
     }
   }

--- a/remote-state-generator/locals.naming.tf
+++ b/remote-state-generator/locals.naming.tf
@@ -2,10 +2,10 @@
 # Licensed under the MIT License.
 
 locals {
-  rg_name     = azurenoopsutils_resource_name.rg.result
+  rg_name     = popsrox_resource_name.rg.result
   location    = var.location
   environment = "state"
   kv_name     = "${var.org_name}statekv${random_string.rand.result}"
-  sa_name     = azurenoopsutils_resource_name.sa.result
-  sc_name     = azurenoopsutils_resource_name.sc.result
+  sa_name     = popsrox_resource_name.sa.result
+  sc_name     = popsrox_resource_name.sc.result
 }

--- a/remote-state-generator/resources.noopsutils.tf
+++ b/remote-state-generator/resources.noopsutils.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # Resource Group NoOpsUtils
-resource "azurenoopsutils_resource_name" "rg" {
+resource "popsrox_resource_name" "rg" {
   name          = "resourcegroup"
   resource_type = "azurerm_resource_group"
   prefixes      = [var.org_name, local.environment, var.workload_name]
@@ -13,7 +13,7 @@ resource "azurenoopsutils_resource_name" "rg" {
 }
 
 # Storage Account NoOpsUtils
-resource "azurenoopsutils_resource_name" "sa" {
+resource "popsrox_resource_name" "sa" {
   name          = "sa"
   resource_type = "azurerm_storage_account"
   prefixes      = [var.org_name, local.environment, var.workload_name]
@@ -23,7 +23,7 @@ resource "azurenoopsutils_resource_name" "sa" {
 }
 
 # Storage Container NoOpsUtils
-resource "azurenoopsutils_resource_name" "sc" {
+resource "popsrox_resource_name" "sc" {
   name          = "sc"
   resource_type = "azurerm_storage_container"
   prefixes      = [var.org_name, local.environment, var.workload_name]

--- a/remote-state-generator/versions.tf
+++ b/remote-state-generator/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/remote-state-generator/versions.tf
+++ b/remote-state-generator/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/remote-state-generator/versions.tf
+++ b/remote-state-generator/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }


### PR DESCRIPTION
## Summary
Replace the `azurenoops/azurenoopsutils` Terraform provider with `POps-Rox/popsrox-utils` across the module and root configuration. All resource type declarations, local references, versions constraints, and documentation have been updated.

## Changes
- `remote-state-generator/versions.tf`: Renamed provider block key `azurenoopsutils` → `popsrox-utils`; updated source to `POps-Rox/popsrox-utils`
- `modules.remotestate.tf`: Same provider block rename in root required_providers block
- `remote-state-generator/resources.noopsutils.tf`: Renamed resource type `azurenoopsutils_resource_name` → `popsrox_resource_name` for all three resources (rg, sa, sc)
- `remote-state-generator/locals.naming.tf`: Updated all resource references to match new type name
- `README.md`: Updated TF Registry badge URL (org `azurenoops` → `POps-Rox`) and provider snippet (`POps-Rox/azurenoopsutils` → `POps-Rox/popsrox-utils`)
- `docs/index.md`: Same badge and provider snippet fixes as README

## Notes
`actionsTemplates/*.yaml` still reference `azurenoops/terraform-github-actions` — `POps-Rox/terraform-github-actions` does not yet exist. Tracked in issue #5.

## Testing
- `terraform fmt -recursive` — clean, no reformatting needed
- `terraform validate` skipped — provider not yet on registry

Closes #4