### PR TITLE
fix: replace azurenoops/terraform-github-actions with POps-Rox fork

### DIFF
--- a/actionsTemplates/tfapply.yaml
+++ b/actionsTemplates/tfapply.yaml
@@ -42,7 +42,7 @@ jobs:
               ;;
           esac
       - name: terraform apply
-        uses: azurenoops/terraform-github-actions/terraform-apply@v1.34.2
+        uses: POps-Rox/terraform-gh-actions/terraform-apply@v1.0.0
         with: 
           path: ${{ env.SRC_PATH}}
           backend_config: |

--- a/actionsTemplates/tfapply.yaml
+++ b/actionsTemplates/tfapply.yaml
@@ -20,8 +20,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Check Commit
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-          case "${{ github.event.head_commit.message}}" in
+          case "$COMMIT_MSG" in
             *"[workload short-code]"*)
               echo "Setting TF_KEY and SRC to match [workload short-code] case"
               echo "TF_KEY=${{ secrets.AZURE_[workload short-code]_KEY }}" >> $GITHUB_ENV

--- a/actionsTemplates/tfdestroy.yaml
+++ b/actionsTemplates/tfdestroy.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: terraform destroy
-        uses: azurenoops/terraform-github-actions/terraform-destroy@v1.34.2
+        uses: POps-Rox/terraform-gh-actions/terraform-destroy@v1.0.0
         with:
           path: ${{github.event.inputs.TF_DIR}}
           backend_config: |

--- a/actionsTemplates/tfplan.yaml
+++ b/actionsTemplates/tfplan.yaml
@@ -21,8 +21,10 @@ jobs:
             -   name: Checkout
                 uses: actions/checkout@v3
             -   name: Check Pull
+                env:
+                    PR_TITLE: ${{ github.event.pull_request.title }}
                 run: |
-                    case "${{ github.event.pull_request.title }}" in
+                    case "$PR_TITLE" in
                         *"[workspace short-code]"*)
                             echo "Setting TF_KEY and SRC to match [workspace short-code] case"
                             echo "TF_KEY=${{ secrets.AZURE_[workspace short-code]_KEY }}" >> $GITHUB_ENV

--- a/actionsTemplates/tfplan.yaml
+++ b/actionsTemplates/tfplan.yaml
@@ -43,7 +43,7 @@ jobs:
                             ;;
                     esac
             -   name: Terraform plan
-                uses: azurenoops/terraform-github-actions/terraform-plan@v1.34.2
+                uses: POps-Rox/terraform-gh-actions/terraform-plan@v1.0.0
                 with:
                     path: ${{ env.SRC_PATH}}
                     backend_config: |


### PR DESCRIPTION
## Summary
Replace all three `actionsTemplates/` references from `azurenoops/terraform-github-actions@v1.34.2` to `POps-Rox/terraform-gh-actions@v1.0.0`.

## Changes
- `actionsTemplates/tfplan.yaml`: updated `uses:` to POps-Rox fork
- `actionsTemplates/tfapply.yaml`: updated `uses:` to POps-Rox fork
- `actionsTemplates/tfdestroy.yaml`: updated `uses:` to POps-Rox fork

## Verification
- `POps-Rox/terraform-gh-actions` is public ✅
- Fork has identical `terraform-plan`, `terraform-apply`, `terraform-destroy` actions with same inputs ✅
- GHCR base image (`ghcr.io/pops-rox/tf-actions-base:latest`) and actions image both present ✅
- Tagged `v1.0.0` on the fork before updating consumers ✅

Closes #5
Closes #7